### PR TITLE
Update user view on TodoWasMarkedAsDone

### DIFF
--- a/config/prooph.php
+++ b/config/prooph.php
@@ -43,6 +43,7 @@ return [
                         ],
                         \Prooph\Proophessor\Model\Todo\Event\TodoWasMarkedAsDone::class => [
                             \Prooph\Proophessor\Projection\Todo\TodoProjector::class,
+                            \Prooph\Proophessor\Projection\User\UserProjector::class,
                         ],
                     ]
                 ]

--- a/src/Container/Projection/User/UserProjectorFactory.php
+++ b/src/Container/Projection/User/UserProjectorFactory.php
@@ -11,6 +11,7 @@
 namespace Prooph\Proophessor\Container\Projection\User;
 
 use Interop\Container\ContainerInterface;
+use Prooph\Proophessor\Projection\User\UserFinder;
 use Prooph\Proophessor\Projection\User\UserProjector;
 
 /**
@@ -27,6 +28,9 @@ final class UserProjectorFactory
      */
     public function __invoke(ContainerInterface $container)
     {
-        return new UserProjector($container->get('doctrine.connection.default'));
+        return new UserProjector(
+            $container->get('doctrine.connection.default'),
+            $container->get(UserFinder::class)
+        );
     }
 }

--- a/src/Projection/User/UserFinder.php
+++ b/src/Projection/User/UserFinder.php
@@ -51,4 +51,20 @@ final class UserFinder
         $stmt->execute();
         return $stmt->fetch();
     }
+
+    /**
+     * @param $todoId
+     * @return null|\stdClass containing userData
+     */
+    public function findUserOfTodo($todoId)
+    {
+        $stmt = $this->connection->prepare(sprintf(
+            "SELECT u.* FROM %s as u JOIN %s as t ON u.id = t.assignee_id  where t.id = :todo_id",
+            Table::USER,
+            Table::TODO
+        ));
+        $stmt->bindValue('todo_id', $todoId);
+        $stmt->execute();
+        return $stmt->fetch();
+    }
 }

--- a/src/Projection/User/UserProjector.php
+++ b/src/Projection/User/UserProjector.php
@@ -70,6 +70,10 @@ final class UserProjector
         $stmt->execute();
     }
 
+    /**
+     * @param TodoWasMarkedAsDone $event
+     * @throws \RuntimeException if data of the the assigned user can not be found
+     */
     public function onTodoWasMarkedAsDone(TodoWasMarkedAsDone $event)
     {
         $user = $this->userFinder->findUserOfTodo($event->todoId()->toString());


### PR DESCRIPTION
This PR adds the `UserProjector` as a listener to the `TodoWasMarkedAsDone` event so the the user view gets also updated correctly.

@DannyvdSluijs I'm sorry. I've forgotten to list this step in the exercise issue. My bad. Can you review my changes because you are responsible for the exercise :smiley: ?

The `read_user` table needs to be updated too, because read tables are not normalized. Each table corresponds to a view in the UI and includes all data required to serve the UI. This allows for very fast read queries without any expensive joins.

/cc @prolic 