### PR TITLE
Just check that json is in the content type.

### DIFF
--- a/src/App/Commanding/API.php
+++ b/src/App/Commanding/API.php
@@ -88,9 +88,8 @@ final class API
     private function getPayloadFromRequest(RequestInterface $request)
     {
         $contentType = $request->getHeader('Content-Type');
-        $expected    = 'application/json; charset=UTF-8';
 
-        if (empty($contentType) || $expected != $contentType[0]) {
+        if (empty($contentType) || false !== strpos($contentType[0], 'json')) {
             throw new \Exception('Expected Content-Type: ' . $expected);
         }
 

--- a/src/App/Commanding/API.php
+++ b/src/App/Commanding/API.php
@@ -82,17 +82,9 @@ final class API
      *
      * @param RequestInterface $request
      * @return array
-     *
-     * @throws \Exception
      */
     private function getPayloadFromRequest(RequestInterface $request)
     {
-        $contentType = $request->getHeader('Content-Type');
-
-        if (empty($contentType) || false !== strpos($contentType[0], 'json')) {
-            throw new \Exception('Expected Content-Type: ' . $expected);
-        }
-
         $payload = json_decode($request->getBody(), true);
 
         switch (json_last_error()) {


### PR DESCRIPTION
Just check that json is in the content type allows for vendor specific content types like: `application/vnd+prooph.command+json` https://3v4l.org/6vlV1