### PR TITLE
Updated docker docs (php7 image and event store adapter)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ nginx:
     - dataphp
 
 php:
-  image: prooph/php:5.6-fpm-xdebug
+  image: prooph/php:7.0-fpm
   links:
     - mariadb:mariadb
   volumes_from:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,16 +12,44 @@ Docker Compose. Now install the dependencies and start the containers. Docker wi
 starts the containers. This may take a while ...
 
 ```bash
-$ docker run --rm -it --volume $(pwd):/app composer/composer:master install --no-dev -o --prefer-dist --ignore-platform-reqs
+$ docker run --rm -it --volume $(pwd):/app prooph/composer:7.0 install --no-dev -o --prefer-dist --ignore-platform-reqs
 $ docker-compose up -d
 ```
 
-Call the MySQL setup script with:
+If you want to run (or write) unit tests you need to install the dev dependencies as well:
+
+```bash
+$ docker run --rm -it --volume $(pwd):/app prooph/composer:7.0 install -o --prefer-dist --ignore-platform-reqs
+```
+
+### Step 2 - Install event store adapter
+
+prooph offers two database adapters for `prooph/event-store` (at the moment).
+Pick the one you want to play with and install it via composer.
+
+#### Doctrine DBAL Adapter
+Install:
+
+`docker run --rm -it --volume $(pwd):/app prooph/composer:7.0 require prooph/event-store-doctrine-adapter`
+
+Configure the MySQL setup script with:
 
 ```bash
 $ docker-compose run --rm php sh bin/setup_mysql.sh
 ```
 
+#### MongoDB Adapter
+Install:
+
+`docker run --rm -it --volume $(pwd):/app prooph/composer:7.0 require prooph/event-store-mongodb-adapter`
+
+Configure the MongoDB setup script with:
+
+```bash
+$ docker-compose run --rm php sh bin/setup_mongodb.sh
+```
+
+### Step 3 - That's it
 Now open [http://localhost:8080](http://localhost:8080/).
 
 ## Using Vagrant


### PR DESCRIPTION
After the gitter discussions with @sandrokeil and https://github.com/prooph/proophessor-do/issues/65 I updated the installation instructions for using the repo with docker.  It now uses the new php7 image and explains how to install an event store adapter and phpunit.

I also updated docker-compose.yml with the php7 image.