### PR TITLE
[WIP] Todo reminder notification

### DIFF
--- a/config/autoload/dependencies.global.php
+++ b/config/autoload/dependencies.global.php
@@ -41,6 +41,8 @@ return [
             \Prooph\ProophessorDo\Projection\User\UserFinder::class    => \Prooph\ProophessorDo\Container\Projection\User\UserFinderFactory::class,
             \Prooph\ProophessorDo\Projection\Todo\TodoProjector::class => \Prooph\ProophessorDo\Container\Projection\Todo\TodoProjectorFactory::class,
             \Prooph\ProophessorDo\Projection\Todo\TodoFinder::class    => \Prooph\ProophessorDo\Container\Projection\Todo\TodoFinderFactory::class,
+            // Subscriber
+            \Prooph\ProophessorDo\App\Mail\SendTodoReminderMailSubscriber::class => \Prooph\ProophessorDo\Container\App\Mail\SendTodoReminderMailSubscriberFactory::class,
         ],
     ],
 ];

--- a/config/autoload/dependencies.global.php
+++ b/config/autoload/dependencies.global.php
@@ -34,6 +34,7 @@ return [
             \Prooph\ProophessorDo\Model\Todo\Handler\ReopenTodoHandler::class     => \Prooph\ProophessorDo\Container\Model\Todo\ReopenTodoHandlerFactory::class,
             \Prooph\ProophessorDo\Model\Todo\Handler\AddDeadlineToTodoHandler::class => \Prooph\ProophessorDo\Container\Model\Todo\AddDeadlineToTodoHandlerFactory::class,
             \Prooph\ProophessorDo\Model\Todo\Handler\AddReminderToTodoHandler::class => \Prooph\ProophessorDo\Container\Model\Todo\AddReminderToTodoHandlerFactory::class,
+            \Prooph\ProophessorDo\Model\Todo\Handler\RemindTodoAssigneeHandler::class => \Prooph\ProophessorDo\Container\Model\Todo\RemindTodoAssigneeHandlerFactory::class,
             \Prooph\ProophessorDo\Model\Todo\TodoList::class            => \Prooph\ProophessorDo\Container\Infrastructure\Repository\EventStoreTodoListFactory::class,
             // Projections
             \Prooph\ProophessorDo\Projection\User\UserProjector::class => \Prooph\ProophessorDo\Container\Projection\User\UserProjectorFactory::class,

--- a/config/autoload/prooph.global.php
+++ b/config/autoload/prooph.global.php
@@ -53,6 +53,7 @@ return [
                         \Prooph\ProophessorDo\Model\Todo\Command\ReopenTodo::class => \Prooph\ProophessorDo\Model\Todo\Handler\ReopenTodoHandler::class,
                         \Prooph\ProophessorDo\Model\Todo\Command\AddDeadlineToTodo::class => \Prooph\ProophessorDo\Model\Todo\Handler\AddDeadlineToTodoHandler::class,
                         \Prooph\ProophessorDo\Model\Todo\Command\AddReminderToTodo::class => \Prooph\ProophessorDo\Model\Todo\Handler\AddReminderToTodoHandler::class,
+                        \Prooph\ProophessorDo\Model\Todo\Command\RemindTodoAssignee::class => \Prooph\ProophessorDo\Model\Todo\Handler\RemindTodoAssigneeHandler::class,
                     ],
                 ],
             ],
@@ -81,6 +82,9 @@ return [
                             \Prooph\ProophessorDo\Projection\Todo\TodoProjector::class,
                         ],
                         \Prooph\ProophessorDo\Model\Todo\Event\ReminderWasAddedToTodo::class => [
+                            \Prooph\ProophessorDo\Projection\Todo\TodoProjector::class,
+                        ],
+                        \Prooph\ProophessorDo\Model\Todo\Event\TodoAssigneeWasReminded::class => [
                             \Prooph\ProophessorDo\Projection\Todo\TodoProjector::class,
                         ],
                     ],

--- a/config/autoload/prooph.global.php
+++ b/config/autoload/prooph.global.php
@@ -86,6 +86,7 @@ return [
                         ],
                         \Prooph\ProophessorDo\Model\Todo\Event\TodoAssigneeWasReminded::class => [
                             \Prooph\ProophessorDo\Projection\Todo\TodoProjector::class,
+                            \Prooph\ProophessorDo\App\Mail\SendTodoReminderMailSubscriber::class,
                         ],
                     ],
                 ],

--- a/migrations/Version20160308110616.php
+++ b/migrations/Version20160308110616.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Prooph\ProophessorDo\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Prooph\ProophessorDo\Projection\Table;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20160308110616 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $todo = $schema->getTable(Table::TODO);
+        $todo->addColumn('reminded', 'boolean', ['default' => 0, 'notnull' => false, 'length' => 1]);
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $todo = $schema->getTable(Table::TODO);
+        $todo->dropColumn('reminded');
+    }
+}

--- a/scripts/send_reminder_notification.php
+++ b/scripts/send_reminder_notification.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This script looks for todos with open reminders and reminds the assignees
+ */
+namespace {
+
+    use Prooph\ProophessorDo\Model\Todo\Command\RemindTodoAssignee;
+    use Prooph\ProophessorDo\Model\Todo\TodoId;
+    use Prooph\ProophessorDo\Projection\Todo\TodoFinder;
+    use Prooph\ServiceBus\CommandBus;
+
+    chdir(dirname(__DIR__));
+
+    // Setup autoloading
+    require 'vendor/autoload.php';
+
+    $container = require 'config/container.php';
+
+    $commandBus = $container->get(CommandBus::class);
+    $todoFinder = $container->get(TodoFinder::class);
+
+    $todos = $todoFinder->findByOpenReminders();
+
+    if (!$todos) {
+        echo "Nothing todo. Exiting.\n";
+        exit;
+    }
+
+    foreach ($todos as $todo) {
+        echo "Send reminder for Todo with id {$todo->id}.\n";
+        $commandBus->dispatch(RemindTodoAssignee::forTodo(TodoId::fromString($todo->id)));
+    }
+
+    echo "Done!\n";
+}

--- a/src/App/Mail/SendTodoReminderMailSubscriber.php
+++ b/src/App/Mail/SendTodoReminderMailSubscriber.php
@@ -1,0 +1,44 @@
+<?php
+namespace Prooph\ProophessorDo\App\Mail;
+
+use Prooph\ProophessorDo\Model\Todo\Event\TodoAssigneeWasReminded;
+use Prooph\ProophessorDo\Projection\Todo\TodoFinder;
+use Prooph\ProophessorDo\Projection\User\UserFinder;
+
+/**
+ * Class SendTodoReminderMailSubscriber
+ *
+ * @package Prooph\ProophessorDo\App\Mail
+ * @author Roman Sachse <r.sachse@ipark-media.de>
+ */
+class SendTodoReminderMailSubscriber
+{
+    /**
+     * @var UserFinder
+     */
+    private $userFinder;
+    /**
+     * @var TodoFinder
+     */
+    private $todoFinder;
+
+    /**
+     * @param UserFinder $userFinder
+     * @param TodoFinder $todoFinder
+     */
+    public function __construct(UserFinder $userFinder, TodoFinder $todoFinder)
+    {
+        $this->userFinder = $userFinder;
+        $this->todoFinder = $todoFinder;
+    }
+
+    public function __invoke(TodoAssigneeWasReminded $event)
+    {
+        $user = $this->userFinder->findById($event->userId()->toString());
+        $todo = $this->todoFinder->findById($event->todoId()->toString());
+
+        $mail = "Hello {$user->name}. This a reminder for {$todo->text}";
+        echo "Sending mail to {$user->email}\n";
+        echo " {$mail}\n\n";
+    }
+}

--- a/src/Container/App/Mail/SendTodoReminderMailSubscriberFactory.php
+++ b/src/Container/App/Mail/SendTodoReminderMailSubscriberFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Prooph\ProophessorDo\Container\App\Mail;
+
+use Interop\Container\ContainerInterface;
+use Prooph\ProophessorDo\App\Mail\SendTodoReminderMailSubscriber;
+use Prooph\ProophessorDo\Projection\Todo\TodoFinder;
+use Prooph\ProophessorDo\Projection\User\UserFinder;
+
+/**
+ * Class RemindTodoAssigneeHandlerFactory
+ *
+ * @package Prooph\ProophessorDo\Container\Model\Todo
+ * @author Roman Sachse <r.sachse@ipark-media.de>
+ */
+class SendTodoReminderMailSubscriberFactory
+{
+    /**
+     * @param ContainerInterface $container
+     * @return SendTodoReminderMailSubscriber
+     */
+    public function __invoke(ContainerInterface $container)
+    {
+        return new SendTodoReminderMailSubscriber($container->get(UserFinder::class), $container->get(TodoFinder::class));
+    }
+}

--- a/src/Container/Model/Todo/RemindTodoAssigneeHandlerFactory.php
+++ b/src/Container/Model/Todo/RemindTodoAssigneeHandlerFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Prooph\ProophessorDo\Container\Model\Todo;
+
+use Interop\Container\ContainerInterface;
+use Prooph\ProophessorDo\Model\Todo\Handler\RemindTodoAssigneeHandler;
+use Prooph\ProophessorDo\Model\Todo\TodoList;
+use Prooph\ProophessorDo\Projection\Todo\TodoFinder;
+
+/**
+ * Class RemindTodoAssigneeHandlerFactory
+ *
+ * @package Prooph\ProophessorDo\Container\Model\Todo
+ * @author Roman Sachse <r.sachse@ipark-media.de>
+ */
+class RemindTodoAssigneeHandlerFactory
+{
+    /**
+     * @param ContainerInterface $container
+     * @return RemindTodoAssigneeHandlerFactory
+     */
+    public function __invoke(ContainerInterface $container)
+    {
+        return new RemindTodoAssigneeHandler($container->get(TodoList::class), $container->get(TodoFinder::class));
+    }
+}

--- a/src/Model/Todo/Command/RemindTodoAssignee.php
+++ b/src/Model/Todo/Command/RemindTodoAssignee.php
@@ -1,0 +1,39 @@
+<?php
+namespace Prooph\ProophessorDo\Model\Todo\Command;
+
+use Prooph\Common\Messaging\Command;
+use Prooph\Common\Messaging\PayloadConstructable;
+use Prooph\Common\Messaging\PayloadTrait;
+use Prooph\ProophessorDo\Model\Todo\TodoId;
+
+/**
+ * Class RemindTodoAssignee
+ *
+ * @package Prooph\ProophessorDo\Model\Todo
+ * @author Roman Sachse <r.sachse@ipark-media.de>
+ */
+final class RemindTodoAssignee extends Command implements PayloadConstructable
+{
+    use PayloadTrait;
+
+    /**
+     *
+     * @param TodoId $todoId
+     * @return RemindTodoAssignee
+     */
+    public static function forTodo(TodoId $todoId)
+    {
+        return new self([
+            'todo_id' => $todoId->toString(),
+        ]);
+    }
+
+
+    /**
+     * @return TodoId
+     */
+    public function todoId()
+    {
+        return TodoId::fromString($this->payload['todo_id']);
+    }
+}

--- a/src/Model/Todo/Event/TodoAssigneeWasReminded.php
+++ b/src/Model/Todo/Event/TodoAssigneeWasReminded.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Prooph\ProophessorDo\Model\Todo\Event;
+
+use Prooph\EventSourcing\AggregateChanged;
+use Prooph\ProophessorDo\Model\Todo\TodoId;
+use Prooph\ProophessorDo\Model\User\UserId;
+
+/**
+ * Class AssigneeWasNotified
+ *
+ * @package Prooph\ProophessorDo\Model\Todo\Event
+ * @author Roman Sachse <r.sachse@ipark-media.de>
+ */
+final class TodoAssigneeWasReminded extends AggregateChanged
+{
+    /**
+     * @var TodoId
+     */
+    private $todoId;
+
+    /**
+     * @var UserId
+     */
+    private $userId;
+
+    /**
+     * @param TodoId $todoId
+     * @param UserId $userId
+     * @return DeadlineWasAddedToTodo
+     */
+    public static function forAssignee(TodoId $todoId, UserId $userId)
+    {
+        $event = self::occur($todoId->toString(), [
+            'todo_id' => $todoId->toString(),
+            'user_id' => $userId->toString(),
+        ]);
+
+        $event->todoId = $todoId;
+        $event->userId = $userId;
+
+        return $event;
+    }
+
+    /**
+     * @return UserId
+     */
+    public function todoId()
+    {
+        if (!$this->todoId) {
+            $this->todoId = TodoId::fromString($this->payload['todo_id']);
+        }
+
+        return $this->todoId;
+    }
+
+    /**
+     * @return UserId
+     */
+    public function userId()
+    {
+        if (!$this->userId) {
+            $this->userId = UserId::fromString($this->payload['user_id']);
+        }
+
+        return $this->userId;
+    }
+}

--- a/src/Model/Todo/Exception/InvalidReminder.php
+++ b/src/Model/Todo/Exception/InvalidReminder.php
@@ -40,4 +40,13 @@ final class InvalidReminder extends \Exception
             $reminder->createdOn()
         ));
     }
+    /**
+     * @return InvalidReminder
+     */
+    public static function alreadyReminded()
+    {
+        return new self(sprintf(
+            'The assignee was already reminded.'
+        ));
+    }
 }

--- a/src/Model/Todo/Handler/RemindTodoAssigneeHandler.php
+++ b/src/Model/Todo/Handler/RemindTodoAssigneeHandler.php
@@ -1,0 +1,65 @@
+<?php
+namespace Prooph\ProophessorDo\Model\Todo\Handler;
+
+use Prooph\ProophessorDo\Model\Todo\Command\RemindTodoAssignee;
+use Prooph\ProophessorDo\Model\Todo\Exception\TodoNotFound;
+use Prooph\ProophessorDo\Model\Todo\TodoList;
+use Prooph\ProophessorDo\Projection\Todo\TodoFinder;
+
+/**
+ * Class RemindTodoAssigneeHandler
+ *
+ * @package Prooph\ProophessorDo\Model\Todo
+ * @author Roman Sachse <r.sachse@ipark-media.de>
+ */
+final class RemindTodoAssigneeHandler
+{
+    /**
+     * @var TodoList
+     */
+    private $todoList;
+    /**
+     * @var TodoFinder
+     */
+    private $todoFinder;
+
+    /**
+     * @param TodoList $todoList
+     * @param TodoFinder $todoFinder
+     */
+    public function __construct(TodoList $todoList, TodoFinder $todoFinder)
+    {
+        $this->todoList = $todoList;
+        $this->todoFinder = $todoFinder;
+    }
+
+    /**
+     * @param RemindTodoAssignee $command
+     */
+    public function __invoke(RemindTodoAssignee $command)
+    {
+        $todo = $this->todoList->get($command->todoId());
+        if (!$todo) {
+            throw TodoNotFound::withTodoId($command->todoId());
+        }
+
+        $todoData = $this->todoFinder->findById($command->todoId()->toString());
+
+        if ($todoData->reminded) {
+            var_dump('do nothing, assignee already reminded');
+
+            return;
+        }
+
+        $reminder = new \DateTimeImmutable($todoData->reminder, new \DateTimeZone('UTC'));
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        if ($reminder > $now) {
+            var_dump('do nothing, reminder in future');
+
+            return;
+        }
+
+        $todo->remindAssignee();
+    }
+}

--- a/src/Projection/Todo/TodoFinder.php
+++ b/src/Projection/Todo/TodoFinder.php
@@ -33,6 +33,7 @@ final class TodoFinder
     public function __construct(Connection $connection)
     {
         $this->connection = $connection;
+        $this->connection->setFetchMode(\PDO::FETCH_OBJ);
     }
 
     /**
@@ -73,5 +74,16 @@ final class TodoFinder
         $stmt->bindValue('todo_id', $todoId);
         $stmt->execute();
         return $stmt->fetch();
+    }
+
+
+    /**
+     * @return \stdClass[] of todoData
+     */
+    public function findByOpenReminders()
+    {
+        $stmt = $this->connection->prepare(sprintf("SELECT * FROM %s where reminder < NOW() AND reminded = 0", Table::TODO));
+        $stmt->execute();
+        return $stmt->fetchAll();
     }
 }

--- a/src/Projection/Todo/TodoProjector.php
+++ b/src/Projection/Todo/TodoProjector.php
@@ -10,6 +10,7 @@
  */
 namespace Prooph\ProophessorDo\Projection\Todo;
 
+use Prooph\ProophessorDo\Model\Todo\Event\TodoAssigneeWasReminded;
 use Prooph\ProophessorDo\Model\Todo\Event\DeadlineWasAddedToTodo;
 use Prooph\ProophessorDo\Model\Todo\Event\ReminderWasAddedToTodo;
 use Prooph\ProophessorDo\Model\Todo\Event\TodoWasPosted;
@@ -109,6 +110,23 @@ final class TodoProjector
             Table::TODO,
             [
                 'reminder' => $event->reminder()->toString(),
+                'reminded' => 0,
+            ],
+            [
+                'id' => $event->todoId()->toString(),
+            ]
+        );
+    }
+    /**
+     * @param TodoAssigneeWasReminded $event
+     * @return void
+     */
+    public function onTodoAssigneeWasReminded(TodoAssigneeWasReminded $event)
+    {
+        $this->connection->update(
+            Table::TODO,
+            [
+                'reminded' => 1,
             ],
             [
                 'id' => $event->todoId()->toString(),


### PR DESCRIPTION
This is a first try to implement a reminder notification for todos. 

I added a send_reminder_notification script which queries the read model for all reminders in the past that have not been handled (reminded column, see migration).

The script uses the command bus to dispatch RemindTodoAssignee commands.
CommandHandler checks with the read model if the reminder is still valid (uses var_dumps for testing purposes).
The todo model sets a "reminded" flag to prevent double notifications.

Questions:
- do you think that this is the right approach 
- where should I put the mail subscriber, I chose: App\Mail\SendTodoReminderMailSubscriber

Todos:
- tests
- write a real mail handler
- cronjob for the worker