### PR TITLE
Escape user input to generated js

### DIFF
--- a/templates/action/user-todo-list.phtml
+++ b/templates/action/user-todo-list.phtml
@@ -28,7 +28,7 @@ if (! $this->user) : ?>
             userId : '<?php echo $this->user->id;  ?>',
             TodoStore : {
                 getAll : function () {
-                    return JSON.parse('<?php echo json_encode($this->todos) ?>');
+                    return JSON.parse('<?php echo addslashes(json_encode($this->todos)) ?>');
                 }
             }
         });


### PR DESCRIPTION
Single quotes are not escaped by json_encode() but do need to be when used in Javascript.
